### PR TITLE
Add Jetty 7, Jetty 8 and Tomcat 7 perf test servers

### DIFF
--- a/jetty7/README.md
+++ b/jetty7/README.md
@@ -1,0 +1,8 @@
+# jetty7
+
+Jetty 7 performance test server
+
+## Running
+
+    $ lein servlet run
+

--- a/jetty7/project.clj
+++ b/jetty7/project.clj
@@ -1,0 +1,16 @@
+(defproject jetty7 "0.1.0-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :warn-on-reflection true
+  :plugins [[lein-servlet "0.2.0"]]
+  :dependencies [[org.clojure/clojure "1.4.0"]]
+  :aot [jetty7.servlet]
+  :servlet {;; uncomment only either of the :deps entries below
+            :deps    [[lein-servlet/adapter-jetty7  "0.2.0"]]
+            ;; :deps    [[lein-servlet/adapter-jetty8  "0.2.0"]]
+            ;; :deps    [[lein-servlet/adapter-tomcat7 "0.2.0"]]
+            :config  {:port 8207}
+            :webapps {"/" {:servlets {"/*" 'jetty7.servlet}
+                           :public "."}}})

--- a/jetty7/src/jetty7/servlet.clj
+++ b/jetty7/src/jetty7/servlet.clj
@@ -1,0 +1,36 @@
+(ns jetty7.servlet
+  (:import (java.io            PrintWriter)
+           (javax.servlet      ServletConfig)
+           (javax.servlet.http HttpServletRequest HttpServletResponse))
+  (:gen-class :extends javax.servlet.http.HttpServlet))
+
+
+(defn -init
+  ([this]
+   (println "Servlet initialized with no params"))
+  ([this ^ServletConfig config]
+   (println "Servlet initialized with servlet config" config)))
+
+
+(defn handle
+  [^HttpServletRequest request ^HttpServletResponse response]
+  (let [template "echo"]
+    (.setContentType response "text/html")
+    (doto ^PrintWriter (.getWriter response)
+      (.println template))))
+
+
+(defn -doGet
+  [this ^HttpServletRequest request ^HttpServletResponse response]
+  (handle request response))
+
+
+(defn -doPost
+  [this ^HttpServletRequest request ^HttpServletResponse response]
+  (handle request response))
+
+
+(defn -destroy
+  [this]
+  (println "Servlet destroyed"))
+

--- a/jetty8/README.md
+++ b/jetty8/README.md
@@ -1,0 +1,8 @@
+# jetty8
+
+Jetty 8 performance test server
+
+## Running
+
+    $ lein servlet run
+

--- a/jetty8/project.clj
+++ b/jetty8/project.clj
@@ -1,0 +1,16 @@
+(defproject jetty8 "0.1.0-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :warn-on-reflection true
+  :plugins [[lein-servlet "0.2.0"]]
+  :dependencies [[org.clojure/clojure "1.4.0"]]
+  :aot [jetty8.servlet]
+  :servlet {;; uncomment only either of the :deps entries below
+            ;; :deps    [[lein-servlet/adapter-jetty7  "0.2.0"]]
+            :deps    [[lein-servlet/adapter-jetty8  "0.2.0"]]
+            ;; :deps    [[lein-servlet/adapter-tomcat7 "0.2.0"]]
+            :config  {:port 8208}
+            :webapps {"/" {:servlets {"/*" 'jetty8.servlet}
+                           :public "."}}})

--- a/jetty8/src/jetty8/servlet.clj
+++ b/jetty8/src/jetty8/servlet.clj
@@ -1,0 +1,36 @@
+(ns jetty8.servlet
+  (:import (java.io            PrintWriter)
+           (javax.servlet      ServletConfig)
+           (javax.servlet.http HttpServletRequest HttpServletResponse))
+  (:gen-class :extends javax.servlet.http.HttpServlet))
+
+
+(defn -init
+  ([this]
+   (println "Servlet initialized with no params"))
+  ([this ^ServletConfig config]
+   (println "Servlet initialized with servlet config" config)))
+
+
+(defn handle
+  [^HttpServletRequest request ^HttpServletResponse response]
+  (let [template "echo"]
+    (.setContentType response "text/html")
+    (doto ^PrintWriter (.getWriter response)
+      (.println template))))
+
+
+(defn -doGet
+  [this ^HttpServletRequest request ^HttpServletResponse response]
+  (handle request response))
+
+
+(defn -doPost
+  [this ^HttpServletRequest request ^HttpServletResponse response]
+  (handle request response))
+
+
+(defn -destroy
+  [this]
+  (println "Servlet destroyed"))
+

--- a/tomcat7/README.md
+++ b/tomcat7/README.md
@@ -1,0 +1,8 @@
+# tomcat7
+
+Tomcat 7 performance test server
+
+## Running
+
+    $ lein servlet run
+

--- a/tomcat7/project.clj
+++ b/tomcat7/project.clj
@@ -1,0 +1,16 @@
+(defproject tomcat7 "0.1.0-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :warn-on-reflection true
+  :plugins [[lein-servlet "0.2.0"]]
+  :dependencies [[org.clojure/clojure "1.4.0"]]
+  :aot [tomcat7.servlet]
+  :servlet {;; uncomment only either of the :deps entries below
+            ;; :deps    [[lein-servlet/adapter-jetty7  "0.2.0"]]
+            ;; :deps    [[lein-servlet/adapter-jetty8  "0.2.0"]]
+            :deps    [[lein-servlet/adapter-tomcat7 "0.2.0"]]
+            :config  {:port 8307}
+            :webapps {"/" {:servlets {"/*" 'tomcat7.servlet}
+                           :public "."}}})

--- a/tomcat7/src/tomcat7/core.clj
+++ b/tomcat7/src/tomcat7/core.clj
@@ -1,0 +1,7 @@
+(ns tomcat7.core)
+
+(defn -main [& args]
+  (println "
+Please invoke this app as follows:
+
+$ lein2 servlet run"))

--- a/tomcat7/src/tomcat7/servlet.clj
+++ b/tomcat7/src/tomcat7/servlet.clj
@@ -1,0 +1,36 @@
+(ns tomcat7.servlet
+  (:import (java.io            PrintWriter)
+           (javax.servlet      ServletConfig)
+           (javax.servlet.http HttpServletRequest HttpServletResponse))
+  (:gen-class :extends javax.servlet.http.HttpServlet))
+
+
+(defn -init
+  ([this]
+   (println "Servlet initialized with no params"))
+  ([this ^ServletConfig config]
+   (println "Servlet initialized with servlet config" config)))
+
+
+(defn handle
+  [^HttpServletRequest request ^HttpServletResponse response]
+  (let [template "echo"]
+    (.setContentType response "text/html")
+    (doto ^PrintWriter (.getWriter response)
+      (.println template))))
+
+
+(defn -doGet
+  [this ^HttpServletRequest request ^HttpServletResponse response]
+  (handle request response))
+
+
+(defn -doPost
+  [this ^HttpServletRequest request ^HttpServletResponse response]
+  (handle request response))
+
+
+(defn -destroy
+  [this]
+  (println "Servlet destroyed"))
+


### PR DESCRIPTION
Added Jetty 7, Jetty 8 and Tomcat 8 performance test servers using new processes - `cd` into each subproject and run `lein servlet run`. Ignore the browser window it tries to open.
