### PR TITLE
upgrade servlet adapters via lein-servlet 0.4.1

### DIFF
--- a/scripts/run-servers.sh
+++ b/scripts/run-servers.sh
@@ -11,7 +11,7 @@ start_server() {
 start_servlet() {
     cd servers/$1
     echo "Starting servlet in $(pwd)..."
-    (nohup lein with-profile 1.5 trampoline servlet  run 1>>../../logs/run-servers 2>&1 &)
+    (nohup lein with-profile 1.7 trampoline servlet  run 1>>../../logs/run-servers 2>&1 &)
     cd ../../
 }
 

--- a/servers/jetty7/project.clj
+++ b/servers/jetty7/project.clj
@@ -3,13 +3,17 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :warn-on-reflection true
-  :plugins [[lein-servlet "0.4.0"]]
-  :dependencies [[org.clojure/clojure "1.5.1"]]
+  :min-lein-version "2.3.3"
+  :global-vars {*warn-on-reflection* true
+                *assert* false}
+  :plugins [[lein-servlet "0.4.1"]]
+  :dependencies [[org.clojure/clojure "1.7.0-alpha5"]]
   :aot [jetty7.servlet]
-  :jvm-opts ["-server" "-XX:+UseConcMarkSweepGC"]
-  :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}}
-  :servlet {:deps    [[lein-servlet/adapter-jetty7  "0.4.0"]]
+  :jvm-opts ["-server" "-Xmx2g"]
+  :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
+             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha5"]]}}
+  :servlet {:deps    [[lein-servlet/adapter-jetty7  "0.4.1"]]
             :config  {:port 8091}
             :webapps {"/" {:servlets {"/*" 'jetty7.servlet}
                            :public "."}}})

--- a/servers/jetty8/project.clj
+++ b/servers/jetty8/project.clj
@@ -3,13 +3,17 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :warn-on-reflection true
-  :plugins [[lein-servlet "0.4.0"]]
-  :dependencies [[org.clojure/clojure "1.5.1"]]
+  :min-lein-version "2.3.3"
+  :global-vars {*warn-on-reflection* true
+                *assert* false}
+  :plugins [[lein-servlet "0.4.1"]]
+  :dependencies [[org.clojure/clojure "1.7.0-alpha5"]]
   :aot [jetty8.servlet]
-  :jvm-opts ["-server" "-XX:+UseConcMarkSweepGC"]
-  :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}}
-  :servlet {:deps    [[lein-servlet/adapter-jetty8  "0.4.0"]]
+  :jvm-opts ["-server" "-Xmx2g"]
+  :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
+             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha5"]]}}
+  :servlet {:deps    [[lein-servlet/adapter-jetty8  "0.4.1"]]
             :config  {:port 8092}
             :webapps {"/" {:servlets {"/*" 'jetty8.servlet}
                            :public "."}}})

--- a/servers/jetty9/project.clj
+++ b/servers/jetty9/project.clj
@@ -3,13 +3,17 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :warn-on-reflection true
-  :plugins [[lein-servlet "0.4.0"]]
-  :dependencies [[org.clojure/clojure "1.5.1"]]
+  :min-lein-version "2.3.3"
+  :global-vars {*warn-on-reflection* true
+                *assert* false}
+  :plugins [[lein-servlet "0.4.1"]]
+  :dependencies [[org.clojure/clojure "1.7.0-alpha5"]]
   :aot [jetty9.servlet]
-  :jvm-opts ["-server" "-XX:+UseConcMarkSweepGC"]
-  :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}}
-  :servlet {:deps    [[lein-servlet/adapter-jetty9  "0.4.0"]]
+  :jvm-opts ["-server" "-Xmx2g"]
+  :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
+             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha5"]]}}
+  :servlet {:deps    [[lein-servlet/adapter-jetty9  "0.4.1"]]
             :config  {:port 8093}
             :webapps {"/" {:servlets {"/*" 'jetty9.servlet}
                            :public "."}}})

--- a/servers/tomcat7/project.clj
+++ b/servers/tomcat7/project.clj
@@ -3,13 +3,17 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :warn-on-reflection true
-  :plugins [[lein-servlet "0.4.0"]]
-  :dependencies [[org.clojure/clojure "1.5.1"]]
+  :min-lein-version "2.3.3"
+  :global-vars {*warn-on-reflection* true
+                *assert* false}
+  :plugins [[lein-servlet "0.4.1"]]
+  :dependencies [[org.clojure/clojure "1.7.0-alpha5"]]
   :aot [tomcat7.servlet]
-  :jvm-opts ["-server" "-XX:+UseConcMarkSweepGC"]
-  :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}}
-  :servlet {:deps    [[lein-servlet/adapter-tomcat7 "0.4.0"]]
+  :jvm-opts ["-server" "-Xmx2g"]
+  :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
+             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha5"]]}}
+  :servlet {:deps    [[lein-servlet/adapter-tomcat7 "0.4.1"]]
             :config  {:port 8090}
             :webapps {"/" {:servlets {"/*" 'tomcat7.servlet}
                            :public "."}}})

--- a/servers/tomcat8/project.clj
+++ b/servers/tomcat8/project.clj
@@ -3,13 +3,17 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :warn-on-reflection true
-  :plugins [[lein-servlet "0.4.0"]]
-  :dependencies [[org.clojure/clojure "1.5.1"]]
+  :min-lein-version "2.3.3"
+  :global-vars {*warn-on-reflection* true
+                *assert* false}
+  :plugins [[lein-servlet "0.4.1"]]
+  :dependencies [[org.clojure/clojure "1.7.0-alpha5"]]
   :aot [tomcat8.servlet]
-  :jvm-opts ["-server" "-XX:+UseConcMarkSweepGC"]
-  :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}}
-  :servlet {:deps    [[lein-servlet/adapter-tomcat8 "0.4.0"]]
+  :jvm-opts ["-server" "-Xmx2g"]
+  :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
+             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha5"]]}}
+  :servlet {:deps    [[lein-servlet/adapter-tomcat8 "0.4.1"]]
             :config  {:port 8098}
             :webapps {"/" {:servlets {"/*" 'tomcat8.servlet}
                            :public "."}}})


### PR DESCRIPTION
Jetty 7/8/9, Tomcat 7/8 adapters upgraded as [listed here](https://github.com/kumarshantanu/lein-servlet/blob/master/CHANGES.md#2015-january-17--041).