### PR TITLE
disable tiered compilation for benchmark runs

### DIFF
--- a/servers/embedded/project.clj
+++ b/servers/embedded/project.clj
@@ -25,7 +25,7 @@
                      :plugins
                      [[lein-pprint  "1.1.2"]
                       [lein-ancient "0.5.5"]]}}
-  :jvm-opts   ["-server" "-Xmx2g"]
+  :jvm-opts   ^:replace ["-server" "-Xmx2g"]
   :repositories
   {"sonatype-oss-public"             "https://oss.sonatype.org/content/groups/public/"
    "Immutant 2.x incremental builds" "http://downloads.immutant.org/incremental/"}

--- a/servers/jetty7/project.clj
+++ b/servers/jetty7/project.clj
@@ -9,7 +9,7 @@
   :plugins [[lein-servlet "0.4.1"]]
   :dependencies [[org.clojure/clojure "1.7.0-alpha5"]]
   :aot [jetty7.servlet]
-  :jvm-opts ["-server" "-Xmx2g"]
+  :jvm-opts ^:replace ["-server" "-Xmx2g"]
   :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha5"]]}}

--- a/servers/jetty8/project.clj
+++ b/servers/jetty8/project.clj
@@ -9,7 +9,7 @@
   :plugins [[lein-servlet "0.4.1"]]
   :dependencies [[org.clojure/clojure "1.7.0-alpha5"]]
   :aot [jetty8.servlet]
-  :jvm-opts ["-server" "-Xmx2g"]
+  :jvm-opts ^:replace ["-server" "-Xmx2g"]
   :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha5"]]}}

--- a/servers/jetty9/project.clj
+++ b/servers/jetty9/project.clj
@@ -9,7 +9,7 @@
   :plugins [[lein-servlet "0.4.1"]]
   :dependencies [[org.clojure/clojure "1.7.0-alpha5"]]
   :aot [jetty9.servlet]
-  :jvm-opts ["-server" "-Xmx2g"]
+  :jvm-opts ^:replace ["-server" "-Xmx2g"]
   :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha5"]]}}

--- a/servers/nginx-clojure/project.clj
+++ b/servers/nginx-clojure/project.clj
@@ -7,7 +7,7 @@
   :dependencies 
   [[org.clojure/clojure    "1.7.0-alpha3"]
     ]
-  :jvm-opts ["-server" "-XX:+UseConcMarkSweepGC"]
+  :jvm-opts ^:replace ["-server" "-XX:+UseConcMarkSweepGC"]
   :profiles {:1.7.0-alpha3 {:dependencies [[org.clojure/clojure "1.7.0-alpha3"]]}}
   :main nginx-clojure
 )

--- a/servers/tomcat7/project.clj
+++ b/servers/tomcat7/project.clj
@@ -9,7 +9,7 @@
   :plugins [[lein-servlet "0.4.1"]]
   :dependencies [[org.clojure/clojure "1.7.0-alpha5"]]
   :aot [tomcat7.servlet]
-  :jvm-opts ["-server" "-Xmx2g"]
+  :jvm-opts ^:replace ["-server" "-Xmx2g"]
   :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha5"]]}}

--- a/servers/tomcat8/project.clj
+++ b/servers/tomcat8/project.clj
@@ -9,7 +9,7 @@
   :plugins [[lein-servlet "0.4.1"]]
   :dependencies [[org.clojure/clojure "1.7.0-alpha5"]]
   :aot [tomcat8.servlet]
-  :jvm-opts ["-server" "-Xmx2g"]
+  :jvm-opts ^:replace ["-server" "-Xmx2g"]
   :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha5"]]}}


### PR DESCRIPTION
by default, leiningen sets the JVM up for startup time, via tiered
compilation (see https://github.com/technomancy/leiningen/wiki/Faster).
This doesn't play properly with benchmarks, because it disables the more
aggressive JIT optimizations, which *can* (but don't always) have a severe
impact on benchmark results. You have to use ^:replace on :jvm-opts to
accomplish this.