### PR TITLE
remove latency graphs for now

### DIFF
--- a/results/1k-keepalive/README.md
+++ b/results/1k-keepalive/README.md
@@ -24,12 +24,6 @@ Text results (table)    | [here](20150217-16-34-table.txt)
 ###### xfeep.2015.02.17 - Throughput
 ![Throughput chart](20150217-16-34-qps.png)
 
-###### xfeep.2015.02.17 - Mean latency
-![Mean latency chart](20150217-16-34-mlat.png)
-
-###### xfeep.2015.02.17 - 99.99% latency
-![99.99% latency chart](20150217-16-34-n4lat.png)
-
 ###### xfeep.2015.02.17 - Errors
 ![Errors chart](20150217-16-34-errs.png)
 

--- a/results/1k-non-keepalive/README.md
+++ b/results/1k-non-keepalive/README.md
@@ -24,12 +24,6 @@ Text results (table)    | [here](20150217-11-17-table.txt)
 ###### xfeep.2015.02.17 - Throughput
 ![Throughput chart](20150217-11-17-qps.png)
 
-###### xfeep.2015.02.17 - Mean latency
-![Mean latency chart](20150217-11-17-mlat.png)
-
-###### xfeep.2015.02.17 - 99.99% latency
-![99.99% latency chart](20150217-11-17-n4lat.png)
-
 ###### xfeep.2015.02.17 - Errors
 ![Errors chart](20150217-11-17-errs.png)
 

--- a/results/60k-keepalive/README.md
+++ b/results/60k-keepalive/README.md
@@ -24,12 +24,6 @@ Text results (table)    | [here](20150217-13-18-table.txt)
 ###### xfeep.2015.02.17 - Throughput
 ![Throughput chart](20150217-13-18-qps.png)
 
-###### xfeep.2015.02.17 - Mean latency
-![Mean latency chart](20150217-13-18-mlat.png)
-
-###### xfeep.2015.02.17 - 99.99% latency
-![99.99% latency chart](20150217-13-18-n4lat.png)
-
 ###### xfeep.2015.02.17 - Errors
 ![Errors chart](20150217-13-18-errs.png)
 

--- a/results/60k-non-keepalive/README.md
+++ b/results/60k-non-keepalive/README.md
@@ -24,12 +24,6 @@ Text results (table)    | [here](20150217-15-00-table.txt)
 ###### xfeep.2015.02.17 - Throughput
 ![Throughput chart](20150217-15-00-qps.png)
 
-###### xfeep.2015.02.17 - Mean latency
-![Mean latency chart](20150217-15-00-mlat.png)
-
-###### xfeep.2015.02.17 - 99.99% latency
-![99.99% latency chart](20150217-15-00-n4lat.png)
-
 ###### xfeep.2015.02.17 - Errors
 ![Errors chart](20150217-15-00-errs.png)
 


### PR DESCRIPTION
This is in response to the issues discussed in #29.  It's not a solution, but at least gets us closer to truth until we have a better way to demonstrate latency.